### PR TITLE
Add /code command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/src/res DESTINATION ${CMAKE_CURRENT_BINARY
 add_executable(bot
 	src/main.cpp
 
-	#globals 
+	#globals
 	src/globals/globals.h
 
 	# commands
@@ -23,6 +23,7 @@ add_executable(bot
 	src/commands/coding_cmd.cpp
 	src/commands/close_cmd.cpp
 	src/commands/ticket_cmd.cpp
+	src/commands/code_cmd.cpp
 
 	# utils
 	src/utils/suggestion/suggestion.cpp

--- a/src/commands/code_cmd.cpp
+++ b/src/commands/code_cmd.cpp
@@ -1,0 +1,15 @@
+#include "commands.h"
+#include "../globals/globals.h"
+
+void cmd::codeCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
+{
+    const std::string title = "Formatting C++ Code";
+    const std::string content = "Please format your C++ code like this:\n\n\\```cpp\nstd::cout << \"foo bar\";\n\\```";
+    dpp::embed embed = dpp::embed()
+        .set_color(globals::color::defaultColor)
+        .set_title(title)
+        .add_field(content, "");
+
+    dpp::message message(event.command.channel_id, embed);
+    event.reply(message);
+}

--- a/src/commands/coding_cmd.cpp
+++ b/src/commands/coding_cmd.cpp
@@ -4,12 +4,12 @@
 void cmd::codingCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
 {
     static int index;
-    std::string question = cmd::utils::readFileLine("res/coding.txt", index);
+    const std::string question = cmd::utils::readFileLine("res/coding.txt", index);
 
     dpp::embed embed = dpp::embed()
         .set_color(globals::color::defaultColor)
         .add_field(question, "");
-    
+
     dpp::message message(event.command.channel_id, embed);
     event.reply(message);
 }

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -3,6 +3,8 @@
 
 #include <iostream>
 #include <dpp/dpp.h>
+#include <dpp/cluster.h>
+#include <dpp/dispatcher.h>
 
 namespace cmd
 {
@@ -33,6 +35,13 @@ namespace cmd
      * @param slashcommand event
      */
     void ticketCommand(dpp::cluster& bot, const dpp::slashcommand_t& event);
+
+    /**
+     * @brief Instruction: Formatting C++ Code on Discord
+     * @param bot
+     * @param slashcommand event
+     */
+    void codeCommand(dpp::cluster& bot, const dpp::slashcommand_t& event);
 
     namespace utils
     {

--- a/src/commands/ticket_cmd.cpp
+++ b/src/commands/ticket_cmd.cpp
@@ -15,11 +15,11 @@ void cmd::ticketCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
         if (!callback.is_error())
         {
             dpp::channel ticketChannel = std::get<dpp::channel>(callback.value);
-            
+
             dpp::message pingMessage = dpp::message(ticketChannel.id, event.command.get_issuing_user().get_mention() + " opened this ticket.");
             bot.message_create(pingMessage);
 
-            dpp::message message(event.command.channel_id, "Ticket" + ticketChannel.get_mention() + " created!");
+            dpp::message message(event.command.channel_id, "Ticket " + ticketChannel.get_mention() + " created!");
             event.reply(message.set_flags(dpp::m_ephemeral));
         }
     });

--- a/src/commands/topic_cmd.cpp
+++ b/src/commands/topic_cmd.cpp
@@ -4,7 +4,7 @@
 void cmd::topicCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
 {
     static int index;
-    std::string topic = cmd::utils::readFileLine("res/topic.txt", index);
+    const std::string topic = cmd::utils::readFileLine("res/topic.txt", index);
 
     dpp::embed embed = dpp::embed()
         .set_color(globals::color::defaultColor)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,8 +10,9 @@ using json = nlohmann::json;
 std::list<cmdStruct> cmdList = {
     { "topic", "Get a topic question", cmd::topicCommand },
     { "coding", "Get a coding question", cmd::codingCommand },
-    { "close", "Close a forum post", cmd::closeCommand },
-    { "ticket", "Open a ticket", cmd::ticketCommand }
+    { "close", "Close a ticket or forum post", cmd::closeCommand },
+    { "ticket", "Open a ticket", cmd::ticketCommand },
+    { "code", "Formatting code on Discord", cmd::codeCommand }
 };
 
 int main()


### PR DESCRIPTION
Added /code command.

This command can be used to display a C++ code formatting instruction.