### PR TITLE
Project index reset when at last index

### DIFF
--- a/src/commands/project_cmd.cpp
+++ b/src/commands/project_cmd.cpp
@@ -5,8 +5,7 @@ using json = nlohmann::json;
 
 void cmd::projectCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
 {
-    static int index = -1;
-    index++;
+    static int index = 0;
 
     std::ifstream projectFile("res/project.json");
     if (!projectFile.is_open())
@@ -26,10 +25,22 @@ void cmd::projectCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
         return;
     }
 
-    if (!data.contains("projects") || !data["projects"].is_array() || index >= data["projects"].size())
+    if (!data.contains("projects") || !data["projects"].is_array())
     {
-        event.reply("Invalid project data or index out of bounds.");
+        event.reply("Invalid project data.");
         return;
+    }
+
+    // If index exceeds the number of projects, reset it to 0
+
+    /* Debugging purposes
+    std::cout << index << std::endl;
+    std::cout << data["projects"].size() << std::endl;
+    */
+
+    if (index >= data["projects"].size())
+    {
+        index = 0;
     }
 
     const auto& project = data["projects"][index];
@@ -42,7 +53,6 @@ void cmd::projectCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
     const std::string projectTitle = project["title"];
     const std::string projectDescription = project["description"];
     const std::string projectHint = project.contains("hint") ? project["hint"] : "No hint available.";
-
 
     dpp::embed embed = dpp::embed()
         .set_color(globals::color::defaultColor)
@@ -97,4 +107,6 @@ void cmd::projectCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
         dpp::message hintMessage(event.command.channel_id, hintEmbed);
         event.reply(hintMessage);
     });
+
+    index++;
 }

--- a/src/commands/project_cmd.cpp
+++ b/src/commands/project_cmd.cpp
@@ -32,12 +32,6 @@ void cmd::projectCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
     }
 
     // If index exceeds the number of projects, reset it to 0
-
-    /* Debugging purposes
-    std::cout << index << std::endl;
-    std::cout << data["projects"].size() << std::endl;
-    */
-
     if (index >= data["projects"].size())
     {
         index = 0;


### PR DESCRIPTION
This pull request includes several changes to the `projectCommand` function in the `src/commands/project_cmd.cpp` file to improve its functionality and readability. The most important changes include fixing the index initialization, ensuring the index resets when it exceeds the number of projects, and moving the index increment to the end of the function.

Improvements to index handling:

* [`src/commands/project_cmd.cpp`](diffhunk://#diff-d6c90aee697f55e8441a41fe774de60b2b3610de08ab31deb5f19ca8f0b3de09L8-R8): Changed the initialization of the `index` variable from `-1` to `0` to avoid starting with an invalid index.
* [`src/commands/project_cmd.cpp`](diffhunk://#diff-d6c90aee697f55e8441a41fe774de60b2b3610de08ab31deb5f19ca8f0b3de09L29-R45): Added a check to reset the `index` to `0` if it exceeds the number of projects, ensuring that the index stays within bounds.
* [`src/commands/project_cmd.cpp`](diffhunk://#diff-d6c90aee697f55e8441a41fe774de60b2b3610de08ab31deb5f19ca8f0b3de09R110-R111): Moved the increment of the `index` variable to the end of the function to ensure it is incremented only after a project is successfully processed.
