### PR TITLE
use std::vector instead of std::list; why would you use a linked list?

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <list>
+#include <vector>
 #include <fstream>
 #include <dpp/dpp.h>
 
@@ -8,7 +8,7 @@
 
 using json = nlohmann::json;
 
-std::list<cmdStruct> cmdList = {
+std::vector<cmdStruct> cmdList = {
     { "topic", "Get a topic question", cmd::topicCommand },
     { "coding", "Get a coding question", cmd::codingCommand },
     { "close", "Close a ticket or forum post", cmd::closeCommand },


### PR DESCRIPTION
Use a std::vector instead of a std::list; There is no real reason to use std::list instead of std::vector for the purpose of simply a constant storage of commands; Vector might even improve cache locality & speed.