### PR TITLE
Update topic_cmd.cpp

### DIFF
--- a/src/commands/topic_cmd.cpp
+++ b/src/commands/topic_cmd.cpp
@@ -4,7 +4,17 @@
 void cmd::topicCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
 {
     static int index;
-    const std::string topic = cmd::utils::readFileLine("res/topic.txt", index);
+    int maxLoadAttempts = 10;
+    
+    for(int i = 0; i < maxLoadAttempts; i++) // check if topic string is empty up to x amount of attempts
+    {
+        const std::string topic = cmd::utils::readFileLine("res/topic.txt", index);
+        if(topic.length() > 0)
+        {
+          break;
+        }
+    }
+       
 
     const dpp::embed embed = dpp::embed()
         .set_color(globals::color::defaultColor)


### PR DESCRIPTION
may help mitigate file loading errors

Adds a for loop to topic_cmd.cpp that will retry loading the topic string if it is empty.

adds one int variable for max load attempts in the for loop. this is needed to keep the bot from looping infinitely  in the case the file is not able to be loaded.

Shouldn't break anything but I'm new so please check extra carefully