### PR TITLE
Fix/topic cmd failing randomly

### DIFF
--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -66,6 +66,22 @@ namespace cmd
          * @return content of next line
          */
         std::string readFileLine(const std::string& path, int& index);
+
+        /**
+         * @brief Read a line of a file, but cached
+         * @param path to the file
+         * @param index (not line number)
+         * @return content of that line
+        */
+        std::string readFileLineCached(const std::string& path, int index);
+
+        /**
+         * @brief Gets a random number between range (min, max)
+         * @param min Lower bounds
+         * @param max Upper bounds
+         * @return 
+        */
+        int getRandomNumber(int min, int max);
     }
 }
 

--- a/src/commands/topic_cmd.cpp
+++ b/src/commands/topic_cmd.cpp
@@ -3,7 +3,7 @@
 
 void cmd::topicCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
 {
-    static int index;
+    int index = cmd::utils::getRandomNumber(0, 15);
     const std::string topic = cmd::utils::readFileLine("res/topic.txt", index);
 
     const dpp::embed embed = dpp::embed()

--- a/src/commands/topic_cmd.cpp
+++ b/src/commands/topic_cmd.cpp
@@ -4,7 +4,7 @@
 void cmd::topicCommand(dpp::cluster& bot, const dpp::slashcommand_t& event)
 {
     int index = cmd::utils::getRandomNumber(0, 15);
-    const std::string topic = cmd::utils::readFileLine("res/topic.txt", index);
+    const std::string topic = cmd::utils::readFileLineCached("res/topic.txt", index);
 
     const dpp::embed embed = dpp::embed()
         .set_color(globals::color::defaultColor)

--- a/src/commands/utils.cpp
+++ b/src/commands/utils.cpp
@@ -1,7 +1,9 @@
 #include "commands.h"
 
+#include <random>
 #include <string>
 #include <fstream>
+#include <unordered_map>
 
 std::string cmd::utils::readFileLine(const std::string& path, int &index)
 {
@@ -23,4 +25,58 @@ std::string cmd::utils::readFileLine(const std::string& path, int &index)
     else
         line = "[!] Could not open " + path;
     return line;
+}
+
+std::string cmd::utils::readFileLineCached(const std::string& path, int index)
+{
+    static std::unordered_map<std::string, std::vector<std::string>> seen_files;
+    if (seen_files.find(path) == seen_files.end())
+    {
+        seen_files[path] = {};
+        std::ifstream file(path);
+
+        if (!file.is_open())
+        {
+            return "[!] Could not open " + path;
+        }
+
+        std::string line;
+        while (std::getline(file, line)) {
+            seen_files[path].push_back(line);
+        }
+
+        file.close();
+
+        std::vector<std::string> lines = seen_files.at(path);
+        if (index >= lines.size())
+        {
+            return "[!] Out of range";
+        }
+
+        return lines.at(index);
+    }
+    else
+    {
+        std::vector<std::string> lines = seen_files.at(path);
+        if (index >= lines.size())
+        {
+            return "[!] Out of range";
+        }
+
+        return lines.at(index);
+    }
+}
+
+int cmd::utils::getRandomNumber(int min, int max)
+{
+    if (min > max)
+    {
+        return 0;
+    }
+
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    std::uniform_int_distribution<int> distrib(min, max);
+
+    return distrib(gen);
 }


### PR DESCRIPTION
I added `cmd::util::readFileLineCached` and `cmd::util::getRandomNumber`
This fixes the bug where sometimes /topic failed to get a random topic.